### PR TITLE
Update technical-vision.md

### DIFF
--- a/technical-vision.md
+++ b/technical-vision.md
@@ -1,8 +1,8 @@
 # OpenSSF Technical Vision
 
-We envision a future where participants in the open source software ecosystem focus on delivering high quality products and services, with security handled proactively and as a matter of course.
-- Developers can easily learn secure development practices, and are proactively guided by their tools to apply those practices and automatically informed when action is needed to prevent, remediate, or mitigate security issues.
-- Developers, auditors and regulators can create and easily distribute security policies that are enforced through tooling and automation, providing continuous assurance of the results.
+We envision a future where participants in the open source ecosystem use and share high quality software, with security handled proactively, by default, and as a matter of course:
+- Developers can easily learn secure development practices and are proactively guided by their tools to apply those practices and automatically informed when action is needed to prevent, remediate, or mitigate security issues.
+- Developers, auditors, and regulators can create and easily distribute security policies that are enforced through tooling and automation, providing continuous assurance of the results.
 - Developers and researchers can identify security issues (including unintentional vulnerabilities and malicious software) and have this information swiftly flow backwards through the supply chain to someone who can rapidly address the issue.
 - Community members can provide information and notifications about product defects, mitigations, quality, and supportability and have this information rapidly flow forward across the ecosystem system to all users, and users can rapidly update their software or implement mitigations as appropriate.
 


### PR DESCRIPTION
* Removed the words 'products and services' from first sentence and used the general term 'software'
* Added a clause for 'by default' in the first sentence to capture this important principle.
* Added a colon to the end of the first sentence to show that the following bullets are a continuation of the vision statement (not a description of current status).